### PR TITLE
Fixed length payload

### DIFF
--- a/examples/ggwave-cli/main.cpp
+++ b/examples/ggwave-cli/main.cpp
@@ -11,18 +11,20 @@
 #include <iostream>
 
 int main(int argc, char** argv) {
-    printf("Usage: %s [-cN] [-pN] [-tN]\n", argv[0]);
+    printf("Usage: %s [-cN] [-pN] [-tN] [-lN]\n", argv[0]);
     printf("    -cN - select capture device N\n");
     printf("    -pN - select playback device N\n");
     printf("    -tN - transmission protocol\n");
+    printf("    -lN - fixed payload length of size N, N in [1, %d]\n", GGWave::kMaxLengthFixed);
     printf("\n");
 
     auto argm = parseCmdArguments(argc, argv);
     int captureId = argm["c"].empty() ? 0 : std::stoi(argm["c"]);
     int playbackId = argm["p"].empty() ? 0 : std::stoi(argm["p"]);
     int txProtocol = argm["t"].empty() ? 1 : std::stoi(argm["t"]);
+    int payloadLength = argm["l"].empty() ? -1 : std::stoi(argm["l"]);
 
-    if (GGWave_init(playbackId, captureId) == false) {
+    if (GGWave_init(playbackId, captureId, payloadLength) == false) {
         fprintf(stderr, "Failed to initialize GGWave\n");
         return -1;
     }

--- a/examples/ggwave-cli/main.cpp
+++ b/examples/ggwave-cli/main.cpp
@@ -3,6 +3,8 @@
 #include "ggwave-common.h"
 #include "ggwave-common-sdl2.h"
 
+#include <SDL.h>
+
 #include <cstdio>
 #include <string>
 
@@ -76,6 +78,9 @@ int main(int argc, char** argv) {
     inputThread.join();
 
     GGWave_deinit();
+
+    SDL_CloseAudio();
+    SDL_Quit();
 
     return 0;
 }

--- a/examples/ggwave-common-sdl2.cpp
+++ b/examples/ggwave-common-sdl2.cpp
@@ -78,7 +78,8 @@ void GGWave_setDefaultCaptureDeviceName(std::string name) {
 bool GGWave_init(
         const int playbackId,
         const int captureId,
-        const int payloadLength) {
+        const int payloadLength,
+        const int sampleRateOffset) {
 
     if (g_devIdInp && g_devIdOut) {
         return false;
@@ -118,7 +119,7 @@ bool GGWave_init(
         SDL_AudioSpec playbackSpec;
         SDL_zero(playbackSpec);
 
-        playbackSpec.freq = GGWave::kBaseSampleRate;
+        playbackSpec.freq = GGWave::kBaseSampleRate + sampleRateOffset;
         playbackSpec.format = AUDIO_S16SYS;
         playbackSpec.channels = 1;
         playbackSpec.samples = 16*1024;
@@ -161,7 +162,7 @@ bool GGWave_init(
     if (g_devIdInp == 0) {
         SDL_AudioSpec captureSpec;
         captureSpec = g_obtainedSpecOut;
-        captureSpec.freq = GGWave::kBaseSampleRate;
+        captureSpec.freq = GGWave::kBaseSampleRate + sampleRateOffset;
         captureSpec.format = AUDIO_F32SYS;
         captureSpec.samples = 4096;
 
@@ -282,8 +283,9 @@ bool GGWave_deinit() {
     SDL_CloseAudioDevice(g_devIdInp);
     SDL_PauseAudioDevice(g_devIdOut, 1);
     SDL_CloseAudioDevice(g_devIdOut);
-    SDL_CloseAudio();
-    SDL_Quit();
+
+    g_devIdInp = 0;
+    g_devIdOut = 0;
 
     return true;
 }

--- a/examples/ggwave-common-sdl2.cpp
+++ b/examples/ggwave-common-sdl2.cpp
@@ -77,7 +77,8 @@ void GGWave_setDefaultCaptureDeviceName(std::string name) {
 
 bool GGWave_init(
         const int playbackId,
-        const int captureId) {
+        const int captureId,
+        const int payloadLength) {
 
     if (g_devIdInp && g_devIdOut) {
         return false;
@@ -214,11 +215,12 @@ bool GGWave_init(
         if (g_ggWave) delete g_ggWave;
 
         g_ggWave = new GGWave({
-                g_obtainedSpecInp.freq,
-                g_obtainedSpecOut.freq,
-                GGWave::kDefaultSamplesPerFrame,
-                sampleFormatInp,
-                sampleFormatOut});
+            payloadLength,
+            g_obtainedSpecInp.freq,
+            g_obtainedSpecOut.freq,
+            GGWave::kDefaultSamplesPerFrame,
+            sampleFormatInp,
+            sampleFormatOut});
     }
 
     return true;

--- a/examples/ggwave-common-sdl2.h
+++ b/examples/ggwave-common-sdl2.h
@@ -7,7 +7,7 @@ class GGWave;
 // GGWave helpers
 
 void GGWave_setDefaultCaptureDeviceName(std::string name);
-bool GGWave_init(const int playbackId, const int captureId);
+bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1);
 GGWave * GGWave_instance();
 bool GGWave_mainLoop();
 bool GGWave_deinit();

--- a/examples/ggwave-common-sdl2.h
+++ b/examples/ggwave-common-sdl2.h
@@ -7,7 +7,7 @@ class GGWave;
 // GGWave helpers
 
 void GGWave_setDefaultCaptureDeviceName(std::string name);
-bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1);
+bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1, const int sampleRateOffset = 0);
 GGWave * GGWave_instance();
 bool GGWave_mainLoop();
 bool GGWave_deinit();

--- a/examples/ggwave-rx/main.cpp
+++ b/examples/ggwave-rx/main.cpp
@@ -3,6 +3,8 @@
 #include "ggwave-common.h"
 #include "ggwave-common-sdl2.h"
 
+#include <SDL.h>
+
 #include <cstdio>
 #include <thread>
 
@@ -25,6 +27,9 @@ int main(int argc, char** argv) {
     }
 
     GGWave_deinit();
+
+    SDL_CloseAudio();
+    SDL_Quit();
 
     return 0;
 }

--- a/examples/ggwave-to-file/main.cpp
+++ b/examples/ggwave-to-file/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
 
     fprintf(stderr, "Generating waveform for message '%s' ...\n", message.c_str());
 
-    GGWave ggWave({ GGWave::kBaseSampleRate, sampleRateOut, 1024, GGWAVE_SAMPLE_FORMAT_F32, GGWAVE_SAMPLE_FORMAT_I16 });
+    GGWave ggWave({ -1, GGWave::kBaseSampleRate, sampleRateOut, 1024, GGWAVE_SAMPLE_FORMAT_F32, GGWAVE_SAMPLE_FORMAT_I16 });
     ggWave.init(message.size(), message.data(), ggWave.getTxProtocol(protocolId), volume);
 
     std::vector<char> bufferPCM;

--- a/examples/waver/main.cpp
+++ b/examples/waver/main.cpp
@@ -310,6 +310,7 @@ int main(int argc, char** argv) {
 
     SDL_GL_DeleteContext(gl_context);
     SDL_DestroyWindow(window);
+    SDL_CloseAudio();
     SDL_Quit();
 #endif
 

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1427,7 +1427,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                     int detectedTx = 0;
                     int txNeeded = 0;
                     for (int j = 0; j < rxProtocol.bytesPerTx; ++j) {
-                        if (k*rxProtocol.bytesPerTx + j > totalLength) break;
+                        if (k*rxProtocol.bytesPerTx + j >= totalLength) break;
                         txNeeded += 2;
                         for (int b = 0; b < 16; ++b) {
                             if (tones[2*j + 0].nMax[b] > rxProtocol.framesPerTx/2) {

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1357,6 +1357,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 m_historyIdFixed = 0;
             }
 
+            bool isValid = false;
             for (int rxProtocolId = 0; rxProtocolId < (int) getTxProtocols().size(); ++rxProtocolId) {
                 const auto & rxProtocol = getTxProtocol(rxProtocolId);
 
@@ -1375,7 +1376,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 std::vector<int> detectedBins(2*totalLength);
 
                 struct ToneData {
-                    std::array<int, 16> nMax;
+                    int nMax[16];
                 };
 
                 std::vector<ToneData> tones(nTones);
@@ -1383,7 +1384,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 bool detectedSignal = true;
                 for (int k = 0; k < totalTxs; ++k) {
                     for (auto & tone : tones) {
-                        std::fill(tone.nMax.begin(), tone.nMax.end(), 0);
+                        std::fill(tone.nMax, tone.nMax + 16, 0);
                     }
 
                     for (int i = 0; i < rxProtocol.framesPerTx; ++i) {
@@ -1457,12 +1458,17 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                         if (m_rxData[0] != 0) {
                             fprintf(stderr, "Received sound data successfully: '%s'\n", m_rxData.data());
 
+                            isValid = true;
                             m_hasNewRxData = true;
                             m_lastRxDataLength = m_payloadLength;
                             m_rxProtocol = rxProtocol;
                             m_rxProtocolId = TxProtocolId(rxProtocolId);
                         }
                     }
+                }
+
+                if (isValid) {
+                    break;
                 }
             }
         } else {


### PR DESCRIPTION
Add support for fixed-length payloads.

If the transmitted payload length is known in advance by the receiver, then one can use this new mode of transmission. In this mode, the sound markers are not transmitted and a slightly different decoding scheme is used.

This is very useful for short payloads (1 to 16 bytes) and achieves more pleasant audio tones.

todo : add tests and examples