### PR TITLE
ggwave v0.2.0

### DIFF
--- a/bindings/python/setup-tmpl.py
+++ b/bindings/python/setup-tmpl.py
@@ -38,7 +38,7 @@ setup(
     keywords = "data-over-sound fsk ecc serverless pairing qrcode ultrasound",
     # Build instructions
     ext_modules = [Extension("ggwave",
-                             [ggwave_module_src, "ggwave/src/ggwave.cpp"],
+                             [ggwave_module_src, "ggwave/src/ggwave.cpp", "ggwave/src/resampler.cpp"],
                              include_dirs=["ggwave/include", "ggwave/include/ggwave"],
                              depends=["ggwave/include/ggwave/ggwave.h"],
                              language="c++",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -38,7 +38,7 @@ setup(
     keywords = "data-over-sound fsk ecc serverless pairing qrcode ultrasound",
     # Build instructions
     ext_modules = [Extension("ggwave",
-                             [ggwave_module_src, "ggwave/src/ggwave.cpp"],
+                             [ggwave_module_src, "ggwave/src/ggwave.cpp", "ggwave/src/resampler.cpp"],
                              include_dirs=["ggwave/include", "ggwave/include/ggwave"],
                              depends=["ggwave/include/ggwave/ggwave.h"],
                              language="c++",

--- a/examples/ggwave-cli/main.cpp
+++ b/examples/ggwave-cli/main.cpp
@@ -11,18 +11,20 @@
 #include <iostream>
 
 int main(int argc, char** argv) {
-    printf("Usage: %s [-cN] [-pN] [-tN]\n", argv[0]);
+    printf("Usage: %s [-cN] [-pN] [-tN] [-lN]\n", argv[0]);
     printf("    -cN - select capture device N\n");
     printf("    -pN - select playback device N\n");
     printf("    -tN - transmission protocol\n");
+    printf("    -lN - fixed payload length of size N, N in [1, %d]\n", GGWave::kMaxLengthFixed);
     printf("\n");
 
     auto argm = parseCmdArguments(argc, argv);
     int captureId = argm["c"].empty() ? 0 : std::stoi(argm["c"]);
     int playbackId = argm["p"].empty() ? 0 : std::stoi(argm["p"]);
     int txProtocol = argm["t"].empty() ? 1 : std::stoi(argm["t"]);
+    int payloadLength = argm["l"].empty() ? -1 : std::stoi(argm["l"]);
 
-    if (GGWave_init(playbackId, captureId) == false) {
+    if (GGWave_init(playbackId, captureId, payloadLength) == false) {
         fprintf(stderr, "Failed to initialize GGWave\n");
         return -1;
     }

--- a/examples/ggwave-cli/main.cpp
+++ b/examples/ggwave-cli/main.cpp
@@ -3,6 +3,8 @@
 #include "ggwave-common.h"
 #include "ggwave-common-sdl2.h"
 
+#include <SDL.h>
+
 #include <cstdio>
 #include <string>
 
@@ -76,6 +78,9 @@ int main(int argc, char** argv) {
     inputThread.join();
 
     GGWave_deinit();
+
+    SDL_CloseAudio();
+    SDL_Quit();
 
     return 0;
 }

--- a/examples/ggwave-common-sdl2.cpp
+++ b/examples/ggwave-common-sdl2.cpp
@@ -78,7 +78,8 @@ void GGWave_setDefaultCaptureDeviceName(std::string name) {
 bool GGWave_init(
         const int playbackId,
         const int captureId,
-        const int payloadLength) {
+        const int payloadLength,
+        const int sampleRateOffset) {
 
     if (g_devIdInp && g_devIdOut) {
         return false;
@@ -118,7 +119,7 @@ bool GGWave_init(
         SDL_AudioSpec playbackSpec;
         SDL_zero(playbackSpec);
 
-        playbackSpec.freq = GGWave::kBaseSampleRate;
+        playbackSpec.freq = GGWave::kBaseSampleRate + sampleRateOffset;
         playbackSpec.format = AUDIO_S16SYS;
         playbackSpec.channels = 1;
         playbackSpec.samples = 16*1024;
@@ -161,7 +162,7 @@ bool GGWave_init(
     if (g_devIdInp == 0) {
         SDL_AudioSpec captureSpec;
         captureSpec = g_obtainedSpecOut;
-        captureSpec.freq = GGWave::kBaseSampleRate;
+        captureSpec.freq = GGWave::kBaseSampleRate + sampleRateOffset;
         captureSpec.format = AUDIO_F32SYS;
         captureSpec.samples = 4096;
 
@@ -282,8 +283,9 @@ bool GGWave_deinit() {
     SDL_CloseAudioDevice(g_devIdInp);
     SDL_PauseAudioDevice(g_devIdOut, 1);
     SDL_CloseAudioDevice(g_devIdOut);
-    SDL_CloseAudio();
-    SDL_Quit();
+
+    g_devIdInp = 0;
+    g_devIdOut = 0;
 
     return true;
 }

--- a/examples/ggwave-common-sdl2.cpp
+++ b/examples/ggwave-common-sdl2.cpp
@@ -77,7 +77,8 @@ void GGWave_setDefaultCaptureDeviceName(std::string name) {
 
 bool GGWave_init(
         const int playbackId,
-        const int captureId) {
+        const int captureId,
+        const int payloadLength) {
 
     if (g_devIdInp && g_devIdOut) {
         return false;
@@ -214,11 +215,12 @@ bool GGWave_init(
         if (g_ggWave) delete g_ggWave;
 
         g_ggWave = new GGWave({
-                g_obtainedSpecInp.freq,
-                g_obtainedSpecOut.freq,
-                GGWave::kDefaultSamplesPerFrame,
-                sampleFormatInp,
-                sampleFormatOut});
+            payloadLength,
+            g_obtainedSpecInp.freq,
+            g_obtainedSpecOut.freq,
+            GGWave::kDefaultSamplesPerFrame,
+            sampleFormatInp,
+            sampleFormatOut});
     }
 
     return true;

--- a/examples/ggwave-common-sdl2.h
+++ b/examples/ggwave-common-sdl2.h
@@ -7,7 +7,7 @@ class GGWave;
 // GGWave helpers
 
 void GGWave_setDefaultCaptureDeviceName(std::string name);
-bool GGWave_init(const int playbackId, const int captureId);
+bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1);
 GGWave * GGWave_instance();
 bool GGWave_mainLoop();
 bool GGWave_deinit();

--- a/examples/ggwave-common-sdl2.h
+++ b/examples/ggwave-common-sdl2.h
@@ -7,7 +7,7 @@ class GGWave;
 // GGWave helpers
 
 void GGWave_setDefaultCaptureDeviceName(std::string name);
-bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1);
+bool GGWave_init(const int playbackId, const int captureId, const int payloadLength = -1, const int sampleRateOffset = 0);
 GGWave * GGWave_instance();
 bool GGWave_mainLoop();
 bool GGWave_deinit();

--- a/examples/ggwave-rx/main.cpp
+++ b/examples/ggwave-rx/main.cpp
@@ -3,6 +3,8 @@
 #include "ggwave-common.h"
 #include "ggwave-common-sdl2.h"
 
+#include <SDL.h>
+
 #include <cstdio>
 #include <thread>
 
@@ -25,6 +27,9 @@ int main(int argc, char** argv) {
     }
 
     GGWave_deinit();
+
+    SDL_CloseAudio();
+    SDL_Quit();
 
     return 0;
 }

--- a/examples/ggwave-to-file/main.cpp
+++ b/examples/ggwave-to-file/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
 
     fprintf(stderr, "Generating waveform for message '%s' ...\n", message.c_str());
 
-    GGWave ggWave({ GGWave::kBaseSampleRate, sampleRateOut, 1024, GGWAVE_SAMPLE_FORMAT_F32, GGWAVE_SAMPLE_FORMAT_I16 });
+    GGWave ggWave({ -1, GGWave::kBaseSampleRate, sampleRateOut, 1024, GGWAVE_SAMPLE_FORMAT_F32, GGWAVE_SAMPLE_FORMAT_I16 });
     ggWave.init(message.size(), message.data(), ggWave.getTxProtocol(protocolId), volume);
 
     std::vector<char> bufferPCM;

--- a/examples/waver/common.cpp
+++ b/examples/waver/common.cpp
@@ -1035,7 +1035,7 @@ void renderMain() {
                         {
                             auto col = ImVec4 { 1.0f, 0.0f, 0.0f, 1.0f };
                             col.w = interp;
-                            ImGui::TextColored(col, "Failed to received");
+                            ImGui::TextColored(col, "Failed to receive");
                         }
                         break;
                     case Message::Text:

--- a/examples/waver/main.cpp
+++ b/examples/waver/main.cpp
@@ -310,6 +310,7 @@ int main(int argc, char** argv) {
 
     SDL_GL_DeleteContext(gl_context);
     SDL_DestroyWindow(window);
+    SDL_CloseAudio();
     SDL_Quit();
 #endif
 

--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -230,7 +230,7 @@ public:
     static constexpr auto kMaxLengthVarible = 140;
     static constexpr auto kMaxLengthFixed = 16;
     static constexpr auto kMaxSpectrumHistory = 4;
-    static constexpr auto kMaxRecordedFrames = 1024;
+    static constexpr auto kMaxRecordedFrames = 2048;
 
     using Parameters   = ggwave_Parameters;
     using SampleFormat = ggwave_SampleFormat;
@@ -338,6 +338,8 @@ public:
 
     // Rx
 
+    void setRxProtocols(const TxProtocols & rxProtocols) { m_rxProtocols = rxProtocols; }
+
     const TxRxData & getRxData()            const { return m_rxData; }
     const TxProtocol & getRxProtocol()      const { return m_rxProtocol; }
     const TxProtocolId & getRxProtocolId()  const { return m_rxProtocolId; }
@@ -388,6 +390,7 @@ private:
     bool m_receivingData;
     bool m_analyzingData;
 
+    int m_nMarkersSuccess;
     int m_markerFreqStart;
     int m_recvDuration_frames;
 
@@ -410,6 +413,7 @@ private:
     TxRxData m_rxData;
     TxProtocol m_rxProtocol;
     TxProtocolId m_rxProtocolId;
+    TxProtocols m_rxProtocols;
 
     int m_historyId;
     AmplitudeData m_sampleAmplitudeAverage;

--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -378,7 +378,6 @@ private:
 
     const int m_nBitsInMarker;
     const int m_nMarkerFrames;
-    const int m_nPostMarkerFrames;
     const int m_encodedDataOffset;
 
     // common

--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -218,13 +218,14 @@ extern "C" {
 #include <vector>
 #include <map>
 #include <string>
+#include <memory>
 
 class GGWave {
 public:
     static constexpr auto kBaseSampleRate = 48000;
     static constexpr auto kDefaultSamplesPerFrame = 1024;
     static constexpr auto kDefaultVolume = 10;
-    static constexpr auto kMaxSamplesPerFrame = 1024;
+    static constexpr auto kMaxSamplesPerFrame = 2048;
     static constexpr auto kMaxDataBits = 256;
     static constexpr auto kMaxDataSize = 256;
     static constexpr auto kMaxLengthVarible = 140;
@@ -405,6 +406,7 @@ private:
     bool m_hasNewSpectrum;
     SpectrumData m_sampleSpectrum;
     AmplitudeData m_sampleAmplitude;
+    AmplitudeData m_sampleAmplitudeResampled;
     TxRxData m_sampleAmplitudeTmp;
 
     bool m_hasNewRxData;
@@ -437,6 +439,11 @@ private:
     TxRxData m_outputBlockTmp;
     AmplitudeDataI16 m_outputBlockI16;
     AmplitudeDataI16 m_txAmplitudeDataI16;
+
+    // Impl
+    // todo : move all members inside Impl
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
 };
 
 #endif

--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -349,11 +349,8 @@ public:
     bool takeSpectrum(SpectrumData & dst);
 
 private:
-    bool encode_fixed(const CBWaveformOut & cbWaveformOut);
-    void decode_fixed(const CBWaveformInp & cbWaveformInp);
-
-    bool encode_variable(const CBWaveformOut & cbWaveformOut);
-    void decode_variable(const CBWaveformInp & cbWaveformInp);
+    void decode_fixed();
+    void decode_variable();
 
     int maxFramesPerTx() const;
     int minBytesPerTx() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TARGET ggwave)
 
 add_library(${TARGET}
     ggwave.cpp
+    resampler.cpp
     )
 
 target_include_directories(${TARGET} PUBLIC

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1427,7 +1427,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                     int detectedTx = 0;
                     int txNeeded = 0;
                     for (int j = 0; j < rxProtocol.bytesPerTx; ++j) {
-                        if (k*rxProtocol.bytesPerTx + j > totalLength) break;
+                        if (k*rxProtocol.bytesPerTx + j >= totalLength) break;
                         txNeeded += 2;
                         for (int b = 0; b < 16; ++b) {
                             if (tones[2*j + 0].nMax[b] > rxProtocol.framesPerTx/2) {

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1357,6 +1357,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 m_historyIdFixed = 0;
             }
 
+            bool isValid = false;
             for (int rxProtocolId = 0; rxProtocolId < (int) getTxProtocols().size(); ++rxProtocolId) {
                 const auto & rxProtocol = getTxProtocol(rxProtocolId);
 
@@ -1375,7 +1376,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 std::vector<int> detectedBins(2*totalLength);
 
                 struct ToneData {
-                    std::array<int, 16> nMax;
+                    int nMax[16];
                 };
 
                 std::vector<ToneData> tones(nTones);
@@ -1383,7 +1384,7 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                 bool detectedSignal = true;
                 for (int k = 0; k < totalTxs; ++k) {
                     for (auto & tone : tones) {
-                        std::fill(tone.nMax.begin(), tone.nMax.end(), 0);
+                        std::fill(tone.nMax, tone.nMax + 16, 0);
                     }
 
                     for (int i = 0; i < rxProtocol.framesPerTx; ++i) {
@@ -1457,12 +1458,17 @@ void GGWave::decode_fixed(const CBWaveformInp & cbWaveformInp) {
                         if (m_rxData[0] != 0) {
                             fprintf(stderr, "Received sound data successfully: '%s'\n", m_rxData.data());
 
+                            isValid = true;
                             m_hasNewRxData = true;
                             m_lastRxDataLength = m_payloadLength;
                             m_rxProtocol = rxProtocol;
                             m_rxProtocolId = TxProtocolId(rxProtocolId);
                         }
                     }
+                }
+
+                if (isValid) {
+                    break;
                 }
             }
         } else {

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -313,6 +313,8 @@ GGWave::GGWave(const Parameters & parameters) :
     m_hasNewRxData(false),
     m_lastRxDataLength(0),
     m_rxData(kMaxDataSize),
+    m_rxProtocol(getDefaultTxProtocol()),
+    m_rxProtocolId(getDefaultTxProtocolId()),
     m_rxProtocols(getTxProtocols()),
     m_historyId(0),
     m_sampleAmplitudeAverage(kMaxSamplesPerFrame),

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1059,7 +1059,7 @@ void GGWave::decode_variable() {
         }
 
         if (isReceiving) {
-            if (++m_nMarkersSuccess > 4) {
+            if (++m_nMarkersSuccess >= 4) {
             } else {
                 isReceiving = false;
             }
@@ -1107,7 +1107,7 @@ void GGWave::decode_variable() {
         }
 
         if (isEnded) {
-            if (++m_nMarkersSuccess > 4) {
+            if (++m_nMarkersSuccess >= 4) {
             } else {
                 isEnded = false;
             }

--- a/src/ggwave.cpp
+++ b/src/ggwave.cpp
@@ -1061,7 +1061,7 @@ void GGWave::decode_variable() {
         }
 
         if (isReceiving) {
-            if (++m_nMarkersSuccess >= 4) {
+            if (++m_nMarkersSuccess >= 1) {
             } else {
                 isReceiving = false;
             }
@@ -1109,7 +1109,7 @@ void GGWave::decode_variable() {
         }
 
         if (isEnded) {
-            if (++m_nMarkersSuccess >= 4) {
+            if (++m_nMarkersSuccess >= 1) {
             } else {
                 isEnded = false;
             }

--- a/src/resampler.cpp
+++ b/src/resampler.cpp
@@ -1,0 +1,110 @@
+#include "resampler.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+double linear_interp(double first_number, double second_number, double fraction) {
+    return (first_number + ((second_number - first_number)*fraction));
+}
+}
+
+int Resampler::resample(
+        float factor,
+        int nSamples,
+        const float * samplesInp,
+        float * samplesOut) {
+    if (factor != m_lastFactor) {
+        make_sinc();
+        m_lastFactor = factor;
+    }
+
+    int idxInp = 0;
+    int idxOut = 0;
+    int notDone = 1;
+    double time_now = 0.0;
+    long num_samples = nSamples;
+    long int_time = 0;
+    long last_time = 0;
+    float data_in = samplesInp[idxInp];
+    float data_out;
+    double one_over_factor = 1.0;
+    while (notDone) {
+        double temp1 = 0.0;
+        long left_limit = time_now - kWidth + 1;      /* leftmost neighboring sample used for interp.*/
+        long right_limit = time_now + kWidth; /* rightmost leftmost neighboring sample used for interp.*/
+        if (left_limit<0) left_limit = 0;
+        if (right_limit>num_samples) right_limit = num_samples;
+        if (factor<1.0) {
+            for (int j=left_limit;j<right_limit;j++) {
+                temp1 += gimme_data(j-int_time)*sinc(time_now - (double) j);
+            }
+            data_out = temp1;
+        }
+        else {
+            one_over_factor = 1.0 / factor;
+            for (int j=left_limit;j<right_limit;j++) {
+                temp1 += gimme_data(j-int_time)*one_over_factor*sinc(one_over_factor * (time_now - (double) j));
+            }
+            data_out = temp1;
+        }
+
+        //printf("%8.8f %8.8f\n", data_in, data_out);
+        samplesOut[idxOut++] = data_out;
+        time_now += factor;
+        last_time = int_time;
+        int_time = time_now;
+        while(last_time<int_time)      {
+            if (++idxInp == nSamples) {
+                notDone = 0;
+            } else {
+                data_in = samplesInp[idxInp];
+            }
+            new_data(data_in);
+            last_time += 1;
+        }
+        //                if (!(int_time % 1000)) printf("Sample # %li\n",int_time);
+        //if (!(int_time % 1000)) {
+        //    printf(".");
+        //    fflush(stdout);
+        //}
+    }
+
+    return idxOut;
+}
+
+float Resampler::gimme_data(long j) const {
+    return m_delayBuffer[(int) j + kWidth];
+}
+
+void Resampler::new_data(float data) {
+    for (int i = 0; i < kDelaySize - 5; i++) {
+        m_delayBuffer[i] = m_delayBuffer[i + 1];
+    }
+    m_delayBuffer[kDelaySize - 5] = data;
+}
+
+void Resampler::make_sinc() {
+    double temp, win_freq, win;
+    win_freq = M_PI/kWidth/kSamplesPerZeroCrossing;
+    m_sincTable[0] = 1.0;
+    for (int i = 1; i < kWidth*kSamplesPerZeroCrossing;i++) {
+        temp = (double) i*M_PI/kSamplesPerZeroCrossing;
+        m_sincTable[i] = sin(temp)/temp;
+        win = 0.5 + 0.5*cos(win_freq*i);
+        m_sincTable[i] *= win;
+    }
+}
+
+double Resampler::sinc(double x) const {
+    int low;
+    double temp, delta;
+    if (fabs(x) >= kWidth - 1) {
+        return 0.0;
+    } else {
+        temp = fabs(x) * (double) kSamplesPerZeroCrossing;
+        low = temp;          /* these are interpolation steps */
+        delta = temp - low;  /* and can be ommited if desired */
+        return linear_interp(m_sincTable[low], m_sincTable[low + 1], delta);
+    }
+}

--- a/src/resampler.h
+++ b/src/resampler.h
@@ -1,0 +1,32 @@
+#pragma once
+
+class Resampler {
+public:
+    int resample(
+            float factor,
+            int nSamples,
+            const float * samplesInp,
+            float * samplesOut);
+private:
+    float gimme_data(long j) const;
+    void new_data(float data);
+    void make_sinc();
+    double sinc(double x) const;
+
+    /* this controls the number of neighboring samples
+       which are used to interpolate the new samples.  The
+       processing time is linearly related to this width */
+    static const int kWidth = 64;
+
+    static const int kDelaySize = 140;
+
+    /* this defines how finely the sinc function
+       is sampled for storage in the table  */
+    static const int kSamplesPerZeroCrossing = 32;
+
+    float m_sincTable[kWidth*kSamplesPerZeroCrossing] = { 0.0 };
+
+    float m_delayBuffer[3*kWidth] = { 0 };
+
+    float m_lastFactor = -1.0f;
+};

--- a/tests/test-ggwave.cpp
+++ b/tests/test-ggwave.cpp
@@ -189,16 +189,15 @@ int main(int argc, char ** argv) {
         CHECK_F(instance.init(payload.size(), payload.c_str(), 101));
     }
 
-    // capture / playback at different sample rates
-    {
+    // playback / capture at different sample rates
+    for (int srInp = GGWave::kBaseSampleRate/3; srInp <= 2*GGWave::kBaseSampleRate; srInp += 1100) {
         auto parameters = GGWave::getDefaultParameters();
 
-        std::string payload = "hello";
+        std::string payload = "hello123";
 
         // encode
         {
-            parameters.sampleRateInp = 48000;
-            parameters.sampleRateOut = 12000;
+            parameters.sampleRateOut = srInp;
             GGWave instanceOut(parameters);
 
             instanceOut.init(payload, 25);
@@ -211,10 +210,10 @@ int main(int argc, char ** argv) {
 
         // decode
         {
-            parameters.samplesPerFrame *= float(parameters.sampleRateOut)/parameters.sampleRateInp;
-            parameters.sampleRateInp = parameters.sampleRateOut;
+            parameters.sampleRateInp = srInp;
             GGWave instanceInp(parameters);
 
+            instanceInp.setRxProtocols({{instanceInp.getDefaultTxProtocolId(), instanceInp.getDefaultTxProtocol()}});
             instanceInp.decode(kCBWaveformInp.at(parameters.sampleFormatInp));
 
             GGWave::TxRxData result;


### PR DESCRIPTION
- Fixed-length payloads
- Built-in resampling when the input sample rate does not match the base sample rate
- Support the full range of input/output sampling rates from 6kHz to 96kHz
- Add new Dual-Tone (DT) protocols
- Add option to select Rx protocols
- More tests