### PR TITLE
Add interface for changing ggwave's internal logging

### DIFF
--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -90,6 +90,21 @@ extern "C" {
     // the python module and unfortunately had to do it this way
     typedef int ggwave_Instance;
 
+    // Change file stream for internal ggwave logging. NULL - disable logging
+    //
+    //   Intentionally passing it as void * instead of FILE * to avoid including a header
+    //
+    //     // log to standard error
+    //     ggwave_setLogFile(stderr);
+    //
+    //     // log to standard output
+    //     ggwave_setLogFile(stdout);
+    //
+    //     // disable logging
+    //     ggwave_setLogFile(NULL);
+    //
+    GGWAVE_API void ggwave_setLogFile(void * fptr);
+
     // Helper method to get default instance parameters
     GGWAVE_API ggwave_Parameters ggwave_getDefaultParameters(void);
 
@@ -305,6 +320,13 @@ public:
 
     GGWave(const Parameters & parameters);
     ~GGWave();
+
+    // set file stream for the internal ggwave logging
+    //
+    //  By default, ggwave prints internal log messages to stderr.
+    //  To disable logging all together, call this method with nullptr.
+    //
+    static void setLogFile(FILE * fptr);
 
     static const Parameters & getDefaultParameters();
 

--- a/include/ggwave/ggwave.h
+++ b/include/ggwave/ggwave.h
@@ -103,6 +103,8 @@ extern "C" {
     //     // disable logging
     //     ggwave_setLogFile(NULL);
     //
+    //  Note: not thread-safe. Do not call while any GGWave instances are running
+    //
     GGWAVE_API void ggwave_setLogFile(void * fptr);
 
     // Helper method to get default instance parameters
@@ -325,6 +327,8 @@ public:
     //
     //  By default, ggwave prints internal log messages to stderr.
     //  To disable logging all together, call this method with nullptr.
+    //
+    //  Note: not thread-safe. Do not call while any GGWave instances are running
     //
     static void setLogFile(FILE * fptr);
 

--- a/tests/test-ggwave.c
+++ b/tests/test-ggwave.c
@@ -14,6 +14,9 @@
 #define CHECK_F(cond) CHECK(!(cond))
 
 int main() {
+    //ggwave_setLogFile(NULL); // disable logging
+    ggwave_setLogFile(stdout);
+
     ggwave_Parameters parameters = ggwave_getDefaultParameters();
     parameters.sampleFormatInp = GGWAVE_SAMPLE_FORMAT_I16;
     parameters.sampleFormatOut = GGWAVE_SAMPLE_FORMAT_I16;


### PR DESCRIPTION
ref #51 

Using `GGWave::setLogFile()` it is now possible to change the log file
used internally by ggwave, or disable it all together.

The `C` interface function is respectively `ggwave_setLogFile()`

I guess we can design a better interface in the future, but for now this
seems to be simple enough and does the job.