### PR TITLE
ggwave-to-file : update python example

### DIFF
--- a/examples/ggwave-to-file/README.md
+++ b/examples/ggwave-to-file/README.md
@@ -86,8 +86,10 @@ curl -sS 'https://ggwave-to-file.ggerganov.com/?m=Hello world!&p=4' --output hel
 
 ```python
 import requests
+import wave
 
-def ggwave(message: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1):
+
+def ggwave(message: str, file: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1):
 
     url = 'https://ggwave-to-file.ggerganov.com/'
 
@@ -101,22 +103,23 @@ def ggwave(message: str, protocolId: int = 1, sampleRate: float = 48000, volume:
 
     response = requests.get(url, params=params)
 
-    if response == '':
+    if response == '' or b'Usage: ggwave-to-file' in response.content:
         raise SyntaxError('Request failed')
 
-    return response
+    with wave.open(file, 'wb') as f:
+        f.setnchannels(1)
+        f.setframerate(sampleRate)
+        f.setsampwidth(2)
+        f.writeframes(response.context)
 
 ```
 
 ...
 
 ```python
-import sys
 
-# query waveform from server
-result = ggwave("Hello world!")
+# query waveform from server and write to file
+ggwave("Hello world!", "hello_world.wav")
 
-# dump wav file to stdout
-sys.stdout.buffer.write(result.content)
 
 ```

--- a/examples/ggwave-to-file/README.md
+++ b/examples/ggwave-to-file/README.md
@@ -85,20 +85,26 @@ curl -sS 'https://ggwave-to-file.ggerganov.com/?m=Hello world!&p=4' --output hel
 ### python
 
 ```python
+from typing import Dict, Union
 import requests
 import wave
 
 
-def ggwave(message: str, file: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1):
+def ggwave(message: str,
+           file: str,
+           protocolId: int = 1,
+           sampleRate: float = 48000,
+           volume: int = 50,
+           payloadLength: int = -1) -> None:
 
     url = 'https://ggwave-to-file.ggerganov.com/'
 
-    params = {
-        'm': message,       # message to encode
-        'p': protocolId,    # transmission protocol to use
-        's': sampleRate,    # output sample rate
-        'v': volume,        # output volume
-        'l': payloadLength, # if positive - use fixed-length encoding
+    params: Dict[str, Union[str, int, float] = {
+        'm': message,        # message to encode
+        'p': protocolId,     # transmission protocol to use
+        's': sampleRate,     # output sample rate
+        'v': volume,         # output volume
+        'l': payloadLength,  # if positive - use fixed-length encoding
     }
 
     response = requests.get(url, params=params)

--- a/examples/ggwave-to-file/ggwave-to-file.py
+++ b/examples/ggwave-to-file/ggwave-to-file.py
@@ -1,4 +1,3 @@
-import sys
 import requests
 import wave
 

--- a/examples/ggwave-to-file/ggwave-to-file.py
+++ b/examples/ggwave-to-file/ggwave-to-file.py
@@ -1,17 +1,23 @@
+from typing import Dict, Union
 import requests
 import wave
 
 
-def ggwave(message: str, file: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1) -> None:
+def ggwave(message: str,
+           file: str,
+           protocolId: int = 1,
+           sampleRate: float = 48000,
+           volume: int = 50,
+           payloadLength: int = -1) -> None:
 
     url = 'https://ggwave-to-file.ggerganov.com/'
 
-    params = {
-        'm': message,       # message to encode
-        'p': protocolId,    # transmission protocol to use
-        's': sampleRate,    # output sample rate
-        'v': volume,        # output volume
-        'l': payloadLength, # if positive - use fixed-length encoding
+    params: Dict[str, Union[str, int, float]] = {
+        'm': message,        # message to encode
+        'p': protocolId,     # transmission protocol to use
+        's': sampleRate,     # output sample rate
+        'v': volume,         # output volume
+        'l': payloadLength,  # if positive - use fixed-length encoding
     }
 
     response = requests.get(url, params=params)

--- a/examples/ggwave-to-file/ggwave-to-file.py
+++ b/examples/ggwave-to-file/ggwave-to-file.py
@@ -1,7 +1,9 @@
 import sys
 import requests
+import wave
 
-def ggwave(message: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1):
+
+def ggwave(message: str, file: str, protocolId: int = 1, sampleRate: float = 48000, volume: int = 50, payloadLength: int = -1) -> None:
 
     url = 'https://ggwave-to-file.ggerganov.com/'
 
@@ -15,11 +17,15 @@ def ggwave(message: str, protocolId: int = 1, sampleRate: float = 48000, volume:
 
     response = requests.get(url, params=params)
 
-    if response == '':
+    if response == '' or b'Usage: ggwave-to-file' in response.content:
         raise SyntaxError('Request failed')
 
-    return response
+    with wave.open(file, 'wb') as f:
+        f.setnchannels(1)
+        f.setframerate(sampleRate)
+        f.setsampwidth(2)
+        f.writeframes(response.content)
 
-result = ggwave("Hello world!")
 
-sys.stdout.buffer.write(result.content)
+if __name__ == "__main__":
+    ggwave("Hello world!", "hello_world.wav")


### PR DESCRIPTION
I updated the python file in the ggwave-to-file example to throw an error when the usage prompt is displayed on the webpage.  I also added a return type annotation on the function, which is now none, as the script actually writes a .wav file now.