### PR TITLE
Now ggwave python library accepts bytes as input to encode

### DIFF
--- a/bindings/python/ggwave.pyx
+++ b/bindings/python/ggwave.pyx
@@ -25,7 +25,10 @@ def encode(payload, protocolId = 1, volume = 10, instance = None):
         @return Generated audio waveform bytes representing 16-bit signed integer samples.
     """
 
-    cdef bytes data_bytes = payload.encode()
+    if isinstance(payload, str):
+        payload = payload.encode('utf-8')
+    cdef bytes data_bytes = payload
+
     cdef char* cdata = data_bytes
 
     own = False


### PR DESCRIPTION
I made a small change to cython file that encodes the payload only if it's a string. Thus, you can send raw bytes as ggwave messages.
I needed it so much so I made a little contribution.
Thank you for this library, it's great!