### PR TITLE
Fix cython warning; resolve issue #147

### DIFF
--- a/bindings/python/ggwave.pyx
+++ b/bindings/python/ggwave.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3str
 cimport cython
 
 from libc.stdio cimport stderr


### PR DESCRIPTION
This resolves issue #147.

When building `make deb` on my local system, I no longer see the warning.