### PR TITLE
Add 0.4.3 to changelog to fix .deb builds

### DIFF
--- a/bindings/python/debian/changelog
+++ b/bindings/python/debian/changelog
@@ -1,3 +1,9 @@
+ggwave (0.4.3-0) unstable; urgency=medium
+
+  * 0.4.3 release
+
+ --  Georgi Gerganov <ggerganov@gmail.com>  Wed, 15 Apr 2026 17:00:00 +0000
+
 ggwave (0.4.2-0) unstable; urgency=low
 
   * Initial release


### PR DESCRIPTION
This should fix the Debian package builds for the latest release.