### PR TITLE
Emscripten fixup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if (EMSCRIPTEN)
     set(BUILD_SHARED_LIBS_DEFAULT OFF)
 
     option(GGWAVE_WASM_SINGLE_FILE "ggwave: embed WASM inside the generated ggwave.js" ON)
+    set(CMAKE_CXX_STANDARD 17)
 else()
     set(GGWAVE_SUPPORT_SDL2_DEFAULT ON)
     if (WIN32)
@@ -75,7 +76,9 @@ endif()
 
 # main
 
-set(CMAKE_CXX_STANDARD 11)
+if (NOT EMSCRIPTEN)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (GGWAVE_ALL_WARNINGS)

--- a/bindings/python/debian/changelog
+++ b/bindings/python/debian/changelog
@@ -1,3 +1,9 @@
+ggwave (0.4.3-0) unstable; urgency=medium
+
+  * 0.4.3 release
+
+ --  Georgi Gerganov <ggerganov@gmail.com>  Wed, 15 Apr 2026 17:00:00 +0000
+
 ggwave (0.4.2-0) unstable; urgency=low
 
   * Initial release


### PR DESCRIPTION
This builds on my #175 fix to also fix the emscripten CI job by setting C++17. It does so only for emscripten build target and not for the entire project. Note however that while the CI is fixed with these changes there are several warnings that appear to be worth addressing: https://github.com/ioerror/ggwave/actions/runs/24465922826/job/71492829413 

The Debian package change and this change together fix the CI entirely.